### PR TITLE
Fix: Signup and signin page hidden behind navbar on small screens

### DIFF
--- a/frontend/src/components/AuthPage.jsx
+++ b/frontend/src/components/AuthPage.jsx
@@ -178,7 +178,7 @@ const AuthPage = () => {
           </div>
 
           {/* Right Side - Auth Form */}
-          <div className="order-1 lg:order-2 px-4">
+          <div className="order-1 lg:order-2 px-4 mt-20">
             <div className="relative bg-white/5 backdrop-blur-2xl rounded-2xl shadow-2xl border border-white/10 p-6 lg:p-8 max-w-md mx-auto overflow-hidden">
               {/* Form background pattern */}
               <div className="absolute inset-0 opacity-30">


### PR DESCRIPTION
This pull request fixes the issue where the signup and signin forms were partially hidden behind the navbar on small screens. The problem was caused by a lack of sufficient top margin for the form container when the navbar is fixed at the top.

I updated the layout by adding  top margin using Tailwind CSS to ensure both the signup and signin forms are fully visible and accessible on all devices, especially mobile screens.

Changes Made
Added 'mt-20' to the form container for proper spacing below the navbar.
Verified the fix on different device sizes to confirm the forms no longer overlap with the navbar.

Screenshots
Before: 
<img width="444" height="792" alt="Screenshot 2025-10-03 223607" src="https://github.com/user-attachments/assets/f14cd72c-80ac-4419-81bc-83ff12111a77" />
After: 
<img width="478" height="808" alt="image" src="https://github.com/user-attachments/assets/56867c78-930c-4bf0-af66-2ce64a20d3a2" />

Please let me know if further adjustments are needed.
Fixes #7 