### PR TITLE
feat(chat): add responsive toggleable sidebar with scroll lock on mobile

### DIFF
--- a/frontend/src/components/Chat.jsx
+++ b/frontend/src/components/Chat.jsx
@@ -5,6 +5,7 @@ import useChatStore from "../store/chatStore";
 
 const Chat = () => {
   const [input, setInput] = useState("");
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const messagesEndRef = useRef(null);
   const navigate = useNavigate();
 
@@ -29,13 +30,16 @@ const Chat = () => {
 
   const setSelectedContact = (contactId) => {
     useChatStore.setState({ selectedContact: contactId });
+    setSidebarOpen(false); // Close sidebar on mobile after selecting contact
   };
 
+  // Connect socket on mount, disconnect on unmount
   useEffect(() => {
     connectSocket();
     return () => disconnectSocket();
   }, [connectSocket, disconnectSocket]);
 
+  // Fetch contacts on component mount
   useEffect(() => {
     const fetchContactDetails = async () => {
       try {
@@ -47,16 +51,15 @@ const Chat = () => {
     fetchContactDetails();
   }, [fetchContacts]);
 
-  // Separate useEffect for handling contact selection
+  // Auto select first contact if none selected
   useEffect(() => {
     if (contacts.length > 0 && !selectedContact) {
-      // Automatically select the first contact
       const firstContact = contacts[0];
       setSelectedContact(firstContact._id || firstContact.id);
     }
   }, [contacts, selectedContact]);
 
-  // Separate useEffect for fetching messages when selectedContact changes
+  // Fetch messages and subscribe to realtime messages on selectedContact change
   useEffect(() => {
     if (selectedContact) {
       fetchMessages();
@@ -70,7 +73,7 @@ const Chat = () => {
     unSubscribeToMessage,
   ]);
 
-  // Auto scroll to bottom when messages change
+  // Auto scroll to bottom on messages change
   useEffect(() => {
     if (
       messages &&
@@ -82,6 +85,19 @@ const Chat = () => {
     }
   }, [messages]);
 
+  // Disable body scroll when sidebar is open (mobile)
+  useEffect(() => {
+    if (sidebarOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [sidebarOpen]);
+
   const scrollToBottom = () => {
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({
@@ -92,10 +108,12 @@ const Chat = () => {
     }
   };
 
+  const toggleSidebar = () => {
+    setSidebarOpen(!sidebarOpen);
+  };
+
   const handleSend = async (e) => {
     e.preventDefault();
-
-    // Check if we have either text or image to send
     if (!input.trim()) return;
 
     try {
@@ -106,14 +124,39 @@ const Chat = () => {
     }
   };
 
+  const handleKeyPress = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend(e);
+    }
+  };
+
   return (
     <div className="pt-20 min-h-screen bg-gradient-to-br from-red-100 via-orange-100 to-yellow-100">
-      <div className="w-full flex h-[calc(100vh-6rem)] rounded-none shadow-2xl overflow-hidden">
+      <div className="w-full flex h-[calc(100vh-6rem)] rounded-none shadow-2xl overflow-hidden relative">
         {/* Sidebar */}
-        <aside className="w-72 bg-gradient-to-br from-gray-700 via-red-700 to-gray-800 text-white flex flex-col shadow-2xl">
+        <aside
+          className={`
+            bg-gradient-to-br from-gray-700 via-red-700 to-gray-800 text-white flex flex-col shadow-2xl
+            fixed top-0 left-0 h-full w-64 sm:w-72 lg:w-80 z-40 transform transition-transform duration-300
+            lg:relative lg:translate-x-0 lg:flex pt-8
+            ${sidebarOpen ? "translate-x-0" : "-translate-x-full"} 
+          `}
+        >
+          {/* Close button on mobile/tablet */}
+          <div className="flex justify-end lg:hidden p-2 pt-4">
+            <button
+              onClick={toggleSidebar}
+              aria-label="Close contacts sidebar"
+              className="text-white text-2xl sm:text-3xl font-bold hover:text-orange-300 transition-colors"
+            >
+              &times;
+            </button>
+          </div>
+
           {/* Contacts */}
           <div className="flex-1 overflow-y-auto">
-            <h4 className="px-6 py-3 text-lg font-semibold text-orange-300">
+            <h4 className="px-4 sm:px-6 py-3 text-base sm:text-lg font-semibold text-orange-300">
               Contacts
             </h4>
             <ul>
@@ -123,24 +166,22 @@ const Chat = () => {
                 return (
                   <li
                     key={contactId}
-                    className={`flex items-center px-6 py-3 cursor-pointer transition-all duration-200 hover:bg-red-800/40 ${
+                    className={`flex items-center px-4 sm:px-6 py-2.5 sm:py-3 cursor-pointer transition-all duration-200 hover:bg-red-800/40 ${
                       selectedContact === contactId ? "bg-red-800/60" : ""
                     }`}
                     onClick={() => setSelectedContact(contactId)}
                   >
                     <div className="relative mr-3">
                       <img
-                        src={
-                          contact.pic || contact.photo || "/default-avatar.png"
-                        }
+                        src={contact.pic || contact.photo || "/default-avatar.png"}
                         alt={contact.name}
-                        className="w-10 h-10 rounded-full object-cover border-2 border-orange-400"
+                        className="w-9 h-9 sm:w-10 sm:h-10 rounded-full object-cover border-2 border-orange-400"
                       />
                       {isOnline && (
-                        <span className="absolute bottom-0 right-0 block w-3 h-3 bg-green-500 border-2 border-white rounded-full"></span>
+                        <span className="absolute bottom-0 right-0 block w-2.5 h-2.5 sm:w-3 sm:h-3 bg-green-500 border-2 border-white rounded-full" />
                       )}
                     </div>
-                    <span className="font-medium text-base">
+                    <span className="font-medium text-sm sm:text-base">
                       {contact.name}
                     </span>
                   </li>
@@ -150,34 +191,48 @@ const Chat = () => {
           </div>
         </aside>
 
+        {/* Overlay background for sidebar on small screens */}
+        {sidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black bg-opacity-50 z-30 lg:hidden"
+            onClick={toggleSidebar}
+            aria-hidden="true"
+          />
+        )}
+
         {/* Chat Area */}
-        <main className="flex-1 flex flex-col justify-between bg-white/60 backdrop-blur-xl">
+        <main className="flex-1 flex flex-col justify-between bg-white/60 backdrop-blur-xl relative z-10">
           {/* Chat Header */}
           {selectedContact && (
-            <div className="flex items-center px-8 py-6 border-b border-orange-300/30">
+            <div className="flex items-center px-3 sm:px-4 md:px-6 lg:px-8 py-3 sm:py-4 border-b border-orange-300/30">
+              <button
+                onClick={toggleSidebar}
+                className="mr-2 sm:mr-4 lg:hidden text-red-700 text-2xl sm:text-3xl focus:outline-none hover:text-red-500 transition-colors"
+                aria-label="Toggle contacts sidebar"
+              >
+                &#9776;
+              </button>
+
               {(() => {
                 const contact = contacts.find(
                   (c) => (c._id || c.id) === selectedContact
                 );
-                const isOnline =
-                  onlineUsers && onlineUsers.includes(selectedContact);
+                const isOnline = onlineUsers && onlineUsers.includes(selectedContact);
                 return contact ? (
                   <>
-                    <div className="relative mr-4">
+                    <div className="relative mr-2 sm:mr-3 md:mr-4">
                       <img
-                        src={
-                          contact.pic || contact.photo || "/default-avatar.png"
-                        }
+                        src={contact.pic || contact.photo || "/default-avatar.png"}
                         alt={contact.name}
-                        className="w-12 h-12 rounded-full object-cover border-2 border-orange-400"
+                        className="w-10 h-10 sm:w-11 sm:h-11 md:w-12 md:h-12 rounded-full object-cover border-2 border-orange-400"
                       />
                     </div>
                     <div>
-                      <h2 className="text-2xl font-bold text-red-700">
+                      <h2 className="text-lg sm:text-xl md:text-2xl font-bold text-red-700">
                         {contact.name}
                       </h2>
                       <div
-                        className={`text-sm font-semibold mt-1 ${
+                        className={`text-xs sm:text-sm font-semibold mt-0.5 sm:mt-1 ${
                           isOnline ? "text-green-600" : "text-gray-400"
                         }`}
                       >
@@ -186,7 +241,7 @@ const Chat = () => {
                     </div>
                   </>
                 ) : (
-                  <h2 className="text-2xl font-bold text-red-700">
+                  <h2 className="text-lg sm:text-xl md:text-2xl font-bold text-red-700">
                     Loading...
                   </h2>
                 );
@@ -196,78 +251,81 @@ const Chat = () => {
 
           {/* Messages */}
           <div
-            className="flex-1 px-8 py-6 overflow-y-auto flex flex-col gap-3 bg-white/40 scroll-smooth"
+            className="flex-1 px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-5 md:py-6 overflow-y-auto flex flex-col gap-2 sm:gap-3 bg-white/40 scroll-smooth"
             style={{ scrollBehavior: "smooth" }}
           >
-            {selectedContact &&
-              (Array.isArray(messages)
-                ? messages
-                : messages[selectedContact] || []
-              ).map((msg, idx) => {
-                const isOwn =
-                  msg.from === authUser.name || msg.senderId === authUser._id;
-                const hasImage =
-                  msg.imageUrl || msg.image || msg.type === "image";
-                const imageSrc = msg.imageUrl || msg.image;
-                const textContent = msg.text || msg.content || msg.message;
-                return (
+            {(Array.isArray(messages)
+              ? messages
+              : messages[selectedContact] || []
+            ).map((msg, idx) => {
+              const isOwn = 
+                msg.from === authUser.name || msg.senderId === authUser._id;
+              const hasImage =
+                msg.imageUrl || msg.image || msg.type === "image";
+              const imageSrc = msg.imageUrl || msg.image;
+              const textContent = msg.text || msg.content || msg.message;
+              return (
+                <div
+                  key={idx}
+                  className={`flex ${isOwn ? "justify-end" : "justify-start"}`}
+                >
                   <div
-                    key={idx}
-                    className={`flex ${
-                      isOwn ? "justify-end" : "justify-start"
+                    className={`max-w-[85%] sm:max-w-md md:max-w-lg px-3 sm:px-4 py-2 rounded-2xl shadow-lg text-sm sm:text-base ${
+                      isOwn
+                        ? "bg-gradient-to-r from-orange-400 to-yellow-300 text-gray-900"
+                        : "bg-gradient-to-r from-gray-300 to-red-200 text-gray-800"
                     }`}
                   >
-                    <div
-                      className={`max-w-lg px-4 py-2 rounded-2xl shadow-lg text-base ${
-                        isOwn
-                          ? "bg-gradient-to-r from-orange-400 to-yellow-300 text-gray-900"
-                          : "bg-gradient-to-r from-gray-300 to-red-200 text-gray-800"
-                      }`}
-                    >
-                      <span className="font-semibold mr-2">
-                        {isOwn ? "You" : msg.from || msg.senderName}
-                      </span>
-                      {hasImage && imageSrc ? (
-                        <>
-                          <img
-                            src={imageSrc}
-                            alt="Shared image"
-                            className="max-w-xs rounded-lg cursor-pointer hover:opacity-90 transition-opacity mb-1"
-                            onClick={() => window.open(imageSrc, "_blank")}
-                          />
-                          {textContent && (
-                            <div className="mt-1">{textContent}</div>
-                          )}
-                        </>
-                      ) : (
-                        textContent
-                      )}
-                    </div>
+                    <span className="font-semibold mr-2 text-xs sm:text-sm">
+                      {isOwn ? "You" : msg.from || msg.senderName}
+                    </span>
+                    {hasImage && imageSrc ? (
+                      <>
+                        <img
+                          src={imageSrc}
+                          alt="Shared image"
+                          className="max-w-full sm:max-w-xs rounded-lg cursor-pointer hover:opacity-90 transition-opacity mb-1"
+                          onClick={() => window.open(imageSrc, "_blank")}
+                        />
+                        {textContent && (
+                          <div className="mt-1 text-xs sm:text-sm">{textContent}</div>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-xs sm:text-sm md:text-base">{textContent}</span>
+                    )}
                   </div>
-                );
-              })}
+                </div>
+              );
+            })}
             <div ref={messagesEndRef} />
           </div>
 
           {/* Message Input */}
-          <div className="px-8 py-6 bg-white/80 border-t border-orange-300/30">
-            <form onSubmit={handleSend} className="flex items-center gap-2">
+          <div className="px-3 sm:px-4 md:px-6 lg:px-8 py-3 sm:py-4 md:py-5 lg:py-6 bg-white/80 border-t border-orange-300/30">
+            <div className="flex items-center gap-2">
               <input
                 type="text"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
+                onKeyPress={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSend(e);
+                  }
+                }}
                 placeholder="Type your message..."
-                className="flex-1 px-4 py-3 rounded-full border-2 border-orange-300 focus:outline-none focus:border-red-400 text-lg shadow-md bg-white text-gray-900 placeholder-gray-500"
+                className="flex-1 px-3 sm:px-4 py-2 sm:py-2.5 md:py-3 rounded-full border-2 border-orange-300 focus:outline-none focus:border-red-400 text-sm sm:text-base md:text-lg shadow-md bg-white text-gray-900 placeholder-gray-500"
               />
 
               <button
-                type="submit"
-                className="px-6 py-3 rounded-full bg-gradient-to-r from-red-400 to-orange-400 text-white font-bold shadow-lg hover:scale-105 transition-transform duration-200"
+                onClick={handleSend}
+                className="px-4 sm:px-5 md:px-6 py-2 sm:py-2.5 md:py-3 rounded-full bg-gradient-to-r from-red-400 to-orange-400 text-white font-bold text-sm sm:text-base shadow-lg hover:scale-105 transition-transform duration-200 disabled:opacity-50 disabled:hover:scale-100"
                 disabled={!input.trim()}
               >
                 Send
               </button>
-            </form>
+            </div>
           </div>
         </main>
       </div>


### PR DESCRIPTION
# Description
This pull request enhances the chat page UI to deliver a mobile-friendly, responsive sidebar (drawer) for contacts. The sidebar appears by default on large screens and can be toggled via a hamburger menu on mobile/smaller screens. While open on mobile, background scrolling is disabled for improved focus and user experience.
## Changes
- Replaces static/permanent sidebar with a responsive toggleable drawer for contacts.
- Sidebar drawer opens with a hamburger icon on small screens, and closes when clicking outside, selecting a contact, or pressing the close button.
- Disables body scroll when the sidebar is open on mobile to avoid accidental background interaction.
- Sidebar remains visible by default on tablets and desktops for seamless navigation.
- Maintains all existing chat features and data fetching.

## Benefits
- Greatly improves usability and visual hierarchy on mobile devices.
- Prevents content being squeezed/cramped on smaller viewports.
- Modern, app-like drawer behavior meets current UX standards.

## Screenshot:
### Before-
<img width="458" height="810" alt="Screenshot 2025-10-09 001656" src="https://github.com/user-attachments/assets/1bf4f0ae-387c-46b8-819f-d6fb621a0390" />

### After-
<img width="457" height="811" alt="Screenshot 2025-10-09 001727" src="https://github.com/user-attachments/assets/48b1ed33-83d7-4ea5-9efd-677cb1a35e73" />
<img width="460" height="810" alt="Screenshot 2025-10-09 001741" src="https://github.com/user-attachments/assets/4c10789a-7004-4301-a2df-637f88f68f5f" />

close #13 
